### PR TITLE
feat: pass extra arguments to resume command via --

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ No MCP required. The `recall search` CLI fulfills the same purpose. See [Ask it 
 
 ## Customize
 
+### Extra arguments
+
+Pass extra arguments to the resumed CLI using `--`:
+```bash
+recall -- --plugin-dir /path/to/plugin
+recall my search query -- --plugin-dir /path --verbose
+```
+
+When you select a session and press Enter, the extra arguments are appended to the resume command (e.g., `claude --resume <id> --plugin-dir /path/to/plugin`).
+
+### Environment variables
+
 recall's resume commands can be configured with environment variables.
 
 For example, to resume conversations in YOLO mode, add this to your `.bashrc` or `.zshrc`:

--- a/src/app.rs
+++ b/src/app.rs
@@ -83,6 +83,8 @@ pub struct App {
     last_input: Instant,
     /// Error from indexing thread (shown on exit)
     pub index_error: Option<String>,
+    /// Extra arguments to append to the resume command (from -- passthrough)
+    pub resume_args: Vec<String>,
 }
 
 impl App {
@@ -144,6 +146,7 @@ impl App {
             search_pending: false,
             last_input: Instant::now(),
             index_error: None,
+            resume_args: Vec::new(),
         };
 
         // If there's an initial query, run the search immediately
@@ -656,6 +659,7 @@ mod tests {
             search_pending: false,
             last_input: Instant::now(),
             index_error: None,
+            resume_args: Vec::new(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ struct Cli {
     #[arg(long, global = true)]
     reindex: bool,
 
-    /// Initial search query (for interactive TUI mode)
+    /// Initial search query and optional resume args after -- (for interactive TUI mode)
     #[arg(trailing_var_arg = true)]
     query: Vec<String>,
 }
@@ -90,7 +90,16 @@ enum Command {
 }
 
 fn main() -> Result<()> {
-    let cli = Cli::parse();
+    // Split raw args on "--" before clap sees them.
+    // clap consumes "--" internally, so we intercept first:
+    // everything before "--" goes to clap, everything after becomes resume_args.
+    let raw_args: Vec<String> = std::env::args().collect();
+    let (clap_args, resume_args) = match raw_args.iter().rposition(|s| s == "--") {
+        Some(pos) => (raw_args[..pos].to_vec(), raw_args[pos + 1..].to_vec()),
+        None => (raw_args, Vec::new()),
+    };
+
+    let cli = Cli::parse_from(clap_args);
 
     // Handle --reindex
     if cli.reindex {
@@ -135,7 +144,7 @@ fn main() -> Result<()> {
         None => {
             // Interactive TUI mode
             let initial_query = cli.query.join(" ");
-            run_tui(initial_query)
+            run_tui(initial_query, resume_args)
         }
     }
 }
@@ -149,9 +158,10 @@ fn parse_source(source: &Option<String>) -> Result<Option<SessionSource>> {
     }
 }
 
-fn run_tui(initial_query: String) -> Result<()> {
+fn run_tui(initial_query: String, resume_args: Vec<String>) -> Result<()> {
     // Initialize app (starts background indexing automatically)
     let mut app = App::new(initial_query)?;
+    app.resume_args = resume_args;
 
     // Initialize terminal
     let mut terminal = tui::init()?;
@@ -170,7 +180,7 @@ fn run_tui(initial_query: String) -> Result<()> {
 
     // Handle post-exit actions
     if let Some(session) = app.should_resume {
-        resume_session(&session)?;
+        resume_session(&session, &app.resume_args)?;
     } else if let Some(session_id) = app.should_copy {
         copy_to_clipboard(&session_id)?;
         println!("Copied session ID: {}", session_id);
@@ -267,7 +277,7 @@ fn run(terminal: &mut tui::Tui, app: &mut App) -> Result<()> {
 
 /// Resume a session by exec'ing into the appropriate CLI
 #[cfg(unix)]
-fn resume_session(session: &session::Session) -> Result<()> {
+fn resume_session(session: &session::Session, extra_args: &[String]) -> Result<()> {
     use std::os::unix::process::CommandExt;
 
     // Change to conversation's working directory
@@ -275,7 +285,8 @@ fn resume_session(session: &session::Session) -> Result<()> {
         let _ = std::env::set_current_dir(&session.cwd);
     }
 
-    let (program, args) = session.resume_command();
+    let (program, mut args) = session.resume_command();
+    args.extend(extra_args.iter().cloned());
 
     // This replaces the current process - never returns on success
     let err = std::process::Command::new(&program).args(&args).exec();
@@ -285,13 +296,14 @@ fn resume_session(session: &session::Session) -> Result<()> {
 }
 
 #[cfg(not(unix))]
-fn resume_session(session: &session::Session) -> Result<()> {
+fn resume_session(session: &session::Session, extra_args: &[String]) -> Result<()> {
     // Change to conversation's working directory
     if !session.cwd.is_empty() {
         let _ = std::env::set_current_dir(&session.cwd);
     }
 
-    let (program, args) = session.resume_command();
+    let (program, mut args) = session.resume_command();
+    args.extend(extra_args.iter().cloned());
 
     // On non-Unix, just spawn the process
     std::process::Command::new(&program)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -549,18 +549,28 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         Line::from(spans)
     };
 
-    let sessions_count = Span::styled(
+    let mut right_spans = Vec::new();
+    if !app.resume_args.is_empty() {
+        right_spans.push(Span::styled(
+            format!(" +{} args ", app.resume_args.len()),
+            Style::default().fg(t.match_fg),
+        ));
+        right_spans.push(Span::styled(" │ ", dim));
+    }
+    right_spans.push(Span::styled(
         format!(" {} sessions", app.total_sessions),
         dim,
-    );
+    ));
+    let right_line = Line::from(right_spans);
+    let right_width: u16 = right_line.spans.iter().map(|s| s.width() as u16).sum();
 
     let layout = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(0), Constraint::Length(sessions_count.width() as u16)])
+        .constraints([Constraint::Min(0), Constraint::Length(right_width)])
         .split(area);
 
     frame.render_widget(Paragraph::new(hints), layout[0]);
-    frame.render_widget(Paragraph::new(sessions_count), layout[1]);
+    frame.render_widget(Paragraph::new(right_line), layout[1]);
 }
 
 /// Find the wrapped line index that contains the given fragment.


### PR DESCRIPTION
## Summary

Adds support for passing extra arguments to the resumed CLI using the standard `--` separator:

```bash
recall -- --plugin-dir /path/to/plugin
recall my search query -- --plugin-dir /path --verbose
```

When a session is selected, the extra arguments are appended to the resume command (e.g., `claude --resume <id> --plugin-dir /path/to/plugin`).

Proudly vibecoded, scathing reviews warranted.

## Changes

- Intercept raw args before clap to split on `--` (clap consumes `--` internally, so we grab it first)
- Thread the extra args through to `resume_session()` on both Unix and Windows
- Show `+N args` indicator in the status bar when extra args are active
- Add documentation in README under Customize

## Test plan

- [x] `cargo test` — all 88 tests pass (47+13+28)
- [x] `cargo clippy` — clean
- [x] `recall -- --plugin-dir .` → status bar shows `+2 args`, resume appends extra args
- [x] `recall foo bar -- --flag val` → search works, extra args passed on resume
- [x] `recall` (no `--`) → works as before
- [x] `recall --reindex -- --plugin-dir /tmp` → reindex + extra args