### PR TITLE
feat: add GitHub Copilot CLI session support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Search and resume past conversations from Claude Code, Codex CLI, and Factory (Droid).
+Search and resume past conversations from Claude Code, Codex CLI, Factory (Droid), OpenCode, and Copilot CLI.
 
 ## Principles
 
@@ -41,7 +41,7 @@ cargo install --path .
 
 ## Architecture
 
-Rust TUI for searching Claude Code, Codex CLI, and Factory conversation history.
+Rust TUI for searching Claude Code, Codex CLI, Factory, OpenCode, and Copilot CLI conversation history.
 
 - `src/main.rs` - Entry point, event loop, exec into CLI on resume
 - `src/app.rs` - Application state, search logic, background indexing thread
@@ -49,7 +49,7 @@ Rust TUI for searching Claude Code, Codex CLI, and Factory conversation history.
 - `src/tui.rs` - Terminal setup/teardown
 - `src/theme.rs` - Light/dark theme with auto-detection
 - `src/session.rs` - Core types: Session, Message, SearchResult
-- `src/parser/` - JSONL parsers for Claude (`~/.claude/projects/`), Codex (`~/.codex/sessions/`), and Factory (`~/.factory/sessions/`)
+- `src/parser/` - JSONL parsers for Claude (`~/.claude/projects/`), Codex (`~/.codex/sessions/`), Factory (`~/.factory/sessions/`), OpenCode (`~/.local/share/opencode/`), and Copilot CLI (`~/.copilot/session-state/`)
 - `src/index/` - Tantivy full-text search index, stored in `~/Library/Caches/recall/` (macOS) or `~/.cache/recall/` (Linux)
 
 ## Key Patterns

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # recall&nbsp;&nbsp;&nbsp;[![Mentioned in Awesome Claude Code](https://awesome.re/mentioned-badge.svg)](https://github.com/hesreallyhim/awesome-claude-code)
 
-Search and resume your Claude Code conversations. Also supports Codex, OpenCode and Factory (Droid).
+Search and resume your Claude Code conversations. Also supports Codex, OpenCode, Factory (Droid) and Copilot CLI.
 
 **Tip**: Don't like reading? Tell your agent to use `recall search --help` and it'll search for you.
 
@@ -66,6 +66,7 @@ For example, to resume conversations in YOLO mode, add this to your `.bashrc` or
 ```bash
 export RECALL_CLAUDE_CMD="claude --dangerously-skip-permissions --resume {id}"
 export RECALL_CODEX_CMD="codex --dangerously-bypass-approvals-and-sandbox resume {id}"
+export RECALL_COPILOT_CMD="copilot --resume={id}"
 ```
 
 ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod cli;
 
 #[derive(Parser)]
 #[command(name = "recall")]
-#[command(version, about = "Search and resume Claude Code, Codex CLI, Factory, and Copilot conversations")]
+#[command(version, about = "Search and resume Claude Code, Codex CLI, Factory, OpenCode, and Copilot conversations")]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
@@ -30,7 +30,7 @@ enum Command {
         #[arg(required = true)]
         query: Vec<String>,
 
-        /// Filter by source (claude, codex, factory, opencode)
+        /// Filter by source (claude, codex, factory, opencode, copilot)
         #[arg(long, short)]
         source: Option<String>,
 
@@ -65,7 +65,7 @@ enum Command {
         #[arg(long, short, default_value = "20")]
         limit: usize,
 
-        /// Filter by source (claude, codex, factory, opencode)
+        /// Filter by source (claude, codex, factory, opencode, copilot)
         #[arg(long, short)]
         source: Option<String>,
 
@@ -143,7 +143,7 @@ fn main() -> Result<()> {
 fn parse_source(source: &Option<String>) -> Result<Option<SessionSource>> {
     match source {
         Some(s) => SessionSource::parse(s)
-            .ok_or_else(|| anyhow::anyhow!("Invalid source '{}'. Valid: claude, codex, factory, opencode", s))
+            .ok_or_else(|| anyhow::anyhow!("Invalid source '{}'. Valid: claude, codex, factory, opencode, copilot", s))
             .map(Some),
         None => Ok(None),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod cli;
 
 #[derive(Parser)]
 #[command(name = "recall")]
-#[command(version, about = "Search and resume Claude Code, Codex CLI, and Factory conversations")]
+#[command(version, about = "Search and resume Claude Code, Codex CLI, Factory, and Copilot conversations")]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,

--- a/src/parser/copilot.rs
+++ b/src/parser/copilot.rs
@@ -1,0 +1,196 @@
+use crate::session::{Message, Role, Session, SessionSource};
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use super::{join_consecutive_messages, SessionParser};
+
+#[derive(Debug, Deserialize)]
+struct CopilotLine {
+    #[serde(rename = "type")]
+    entry_type: String,
+    data: serde_json::Value,
+    timestamp: Option<String>,
+}
+
+pub struct CopilotParser;
+
+impl SessionParser for CopilotParser {
+    fn can_parse(path: &Path) -> bool {
+        let s = path.to_str().unwrap_or("");
+        (s.contains(".copilot/session-state") || s.contains(".copilot\\session-state"))
+            && path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n == "events.jsonl")
+                .unwrap_or(false)
+    }
+
+    fn parse_file(path: &Path) -> Result<Session> {
+        let file = File::open(path).context("Failed to open file")?;
+        let reader = BufReader::with_capacity(64 * 1024, file);
+
+        let mut session_id: Option<String> = None;
+        let mut cwd: Option<String> = None;
+        let mut git_branch: Option<String> = None;
+        let mut latest_timestamp: Option<DateTime<Utc>> = None;
+        let mut messages: Vec<Message> = Vec::new();
+
+        for line in reader.lines() {
+            let line = line.context("Failed to read line")?;
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let entry: CopilotLine = match serde_json::from_str(&line) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            // Parse timestamp
+            let timestamp = entry
+                .timestamp
+                .as_ref()
+                .and_then(|ts| DateTime::parse_from_rfc3339(ts).ok())
+                .map(|dt| dt.with_timezone(&Utc));
+
+            if let Some(ts) = timestamp {
+                if latest_timestamp.is_none() || ts > latest_timestamp.unwrap() {
+                    latest_timestamp = Some(ts);
+                }
+            }
+
+            match entry.entry_type.as_str() {
+                "session.start" => {
+                    if session_id.is_none() {
+                        session_id = entry.data["sessionId"].as_str().map(|s| s.to_string());
+                    }
+                    if cwd.is_none() {
+                        cwd = entry.data["context"]["cwd"]
+                            .as_str()
+                            .map(|s| s.to_string());
+                    }
+                    if git_branch.is_none() {
+                        git_branch = entry.data["context"]["branch"]
+                            .as_str()
+                            .map(|s| s.to_string());
+                    }
+                }
+                "user.message" => {
+                    if let Some(content) = entry.data["content"].as_str() {
+                        if !content.is_empty() {
+                            messages.push(Message {
+                                role: Role::User,
+                                content: content.to_string(),
+                                timestamp: timestamp.unwrap_or_else(Utc::now),
+                            });
+                        }
+                    }
+                }
+                "assistant.message" => {
+                    if let Some(content) = entry.data["content"].as_str() {
+                        if !content.is_empty() {
+                            messages.push(Message {
+                                role: Role::Assistant,
+                                content: content.to_string(),
+                                timestamp: timestamp.unwrap_or_else(Utc::now),
+                            });
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Fall back to directory name for session ID
+        let session_id = session_id.unwrap_or_else(|| {
+            path.parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+                .unwrap_or("unknown")
+                .to_string()
+        });
+
+        Ok(Session {
+            id: session_id,
+            source: SessionSource::CopilotCli,
+            file_path: path.to_path_buf(),
+            cwd: cwd.unwrap_or_else(|| ".".to_string()),
+            git_branch,
+            timestamp: latest_timestamp.unwrap_or_else(Utc::now),
+            messages: join_consecutive_messages(messages),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_can_parse_copilot_path() {
+        assert!(CopilotParser::can_parse(Path::new(
+            "/home/user/.copilot/session-state/abc-123/events.jsonl"
+        )));
+    }
+
+    #[test]
+    fn test_can_parse_rejects_other_paths() {
+        assert!(!CopilotParser::can_parse(Path::new(
+            "/home/user/.claude/projects/test/session.jsonl"
+        )));
+        assert!(!CopilotParser::can_parse(Path::new(
+            "/home/user/.copilot/session-state/abc-123/workspace.yaml"
+        )));
+    }
+
+    #[test]
+    fn test_parse_events_basic() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let session_dir = dir.path().join(".copilot/session-state/test-id-001");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let events_path = session_dir.join("events.jsonl");
+
+        let content = r#"{"type":"session.start","data":{"sessionId":"test-id-001","context":{"cwd":"/test/project","branch":"main"}},"timestamp":"2026-01-15T10:00:00.000Z"}
+{"type":"user.message","data":{"content":"hello"},"timestamp":"2026-01-15T10:00:05.000Z"}
+{"type":"assistant.turn_start","data":{"turnId":"0"},"timestamp":"2026-01-15T10:00:05.100Z"}
+{"type":"assistant.message","data":{"content":"Hi there!"},"timestamp":"2026-01-15T10:00:10.000Z"}
+{"type":"assistant.turn_end","data":{},"timestamp":"2026-01-15T10:00:10.100Z"}"#;
+
+        std::fs::write(&events_path, content).unwrap();
+
+        let session = CopilotParser::parse_file(&events_path).unwrap();
+        assert_eq!(session.id, "test-id-001");
+        assert_eq!(session.source, SessionSource::CopilotCli);
+        assert_eq!(session.cwd, "/test/project");
+        assert_eq!(session.git_branch, Some("main".to_string()));
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[0].role, Role::User);
+        assert_eq!(session.messages[0].content, "hello");
+        assert_eq!(session.messages[1].role, Role::Assistant);
+        assert_eq!(session.messages[1].content, "Hi there!");
+    }
+
+    #[test]
+    fn test_parse_events_skips_non_messages() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let session_dir = dir.path().join(".copilot/session-state/test-skip");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let events_path = session_dir.join("events.jsonl");
+
+        let content = r#"{"type":"session.start","data":{"sessionId":"test-skip","context":{"cwd":"/"}},"timestamp":"2026-01-15T10:00:00.000Z"}
+{"type":"session.model_change","data":{"newModel":"gpt-4.1"},"timestamp":"2026-01-15T10:00:01.000Z"}
+{"type":"session.info","data":{"infoType":"model","message":"Model changed"},"timestamp":"2026-01-15T10:00:01.000Z"}
+{"type":"session.error","data":{"message":"something failed"},"timestamp":"2026-01-15T10:00:02.000Z"}
+{"type":"user.message","data":{"content":"test"},"timestamp":"2026-01-15T10:00:05.000Z"}"#;
+
+        std::fs::write(&events_path, content).unwrap();
+
+        let session = CopilotParser::parse_file(&events_path).unwrap();
+        assert_eq!(session.messages.len(), 1);
+        assert_eq!(session.messages[0].content, "test");
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,10 +1,12 @@
 mod claude;
 mod codex;
+mod copilot;
 mod factory;
 mod opencode;
 
 pub use claude::ClaudeParser;
 pub use codex::CodexParser;
+pub use copilot::CopilotParser;
 pub use factory::FactoryParser;
 pub use opencode::OpenCodeParser;
 
@@ -118,6 +120,19 @@ pub fn discover_session_files() -> Vec<std::path::PathBuf> {
                 }
             }
         }
+
+        // Copilot CLI: ~/.copilot/session-state/*/events.jsonl
+        let copilot_dir = home.join(".copilot/session-state");
+        if copilot_dir.exists() {
+            if let Ok(sessions) = std::fs::read_dir(&copilot_dir) {
+                for session in sessions.flatten() {
+                    let events = session.path().join("events.jsonl");
+                    if events.exists() {
+                        files.push(events);
+                    }
+                }
+            }
+        }
     }
 
     files
@@ -133,6 +148,8 @@ pub fn parse_session_file(path: &Path) -> Result<Session> {
         FactoryParser::parse_file(path)
     } else if OpenCodeParser::can_parse(path) {
         OpenCodeParser::parse_file(path)
+    } else if CopilotParser::can_parse(path) {
+        CopilotParser::parse_file(path)
     } else {
         anyhow::bail!("Unknown session file format: {:?}", path)
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -12,6 +12,8 @@ pub enum SessionSource {
     Factory,
     #[serde(rename = "opencode")]
     OpenCode,
+    #[serde(rename = "copilot")]
+    CopilotCli,
 }
 
 impl SessionSource {
@@ -21,6 +23,7 @@ impl SessionSource {
             SessionSource::CodexCli => "codex",
             SessionSource::Factory => "factory",
             SessionSource::OpenCode => "opencode",
+            SessionSource::CopilotCli => "copilot",
         }
     }
 
@@ -30,6 +33,7 @@ impl SessionSource {
             "codex" => Some(SessionSource::CodexCli),
             "factory" => Some(SessionSource::Factory),
             "opencode" => Some(SessionSource::OpenCode),
+            "copilot" => Some(SessionSource::CopilotCli),
             _ => None,
         }
     }
@@ -40,6 +44,7 @@ impl SessionSource {
             SessionSource::CodexCli => "Codex",
             SessionSource::Factory => "Factory",
             SessionSource::OpenCode => "OpenCode",
+            SessionSource::CopilotCli => "Copilot",
         }
     }
 
@@ -49,6 +54,7 @@ impl SessionSource {
             SessionSource::CodexCli => "■",
             SessionSource::Factory => "◆",
             SessionSource::OpenCode => "○",
+            SessionSource::CopilotCli => "▲",
         }
     }
 }
@@ -105,6 +111,7 @@ impl Session {
             SessionSource::CodexCli => "RECALL_CODEX_CMD",
             SessionSource::Factory => "RECALL_FACTORY_CMD",
             SessionSource::OpenCode => "RECALL_OPENCODE_CMD",
+            SessionSource::CopilotCli => "RECALL_COPILOT_CMD",
         };
 
         if let Ok(cmd) = std::env::var(env_var) {
@@ -135,6 +142,10 @@ impl Session {
             SessionSource::OpenCode => (
                 "opencode".to_string(),
                 vec!["--session".to_string(), self.id.clone()],
+            ),
+            SessionSource::CopilotCli => (
+                "copilot".to_string(),
+                vec![format!("--resume={}", self.id)],
             ),
         }
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -44,6 +44,10 @@ pub struct Theme {
     pub opencode_bubble_bg: Color,
     /// OpenCode source indicator color
     pub opencode_source: Color,
+    /// Copilot message bubble background
+    pub copilot_bubble_bg: Color,
+    /// Copilot source indicator color
+    pub copilot_source: Color,
     /// Scope indicator background (slightly different from search_bg)
     pub scope_bg: Color,
     /// Scope keycap background (for "/" key)
@@ -89,6 +93,8 @@ impl Theme {
             factory_source: Color::Rgb(150, 120, 200), // Google purple
             opencode_bubble_bg: Color::Rgb(30, 40, 55), // subtle blue tint
             opencode_source: Color::Rgb(100, 150, 255), // sky blue
+            copilot_bubble_bg: Color::Rgb(30, 45, 45), // subtle teal tint
+            copilot_source: Color::Rgb(100, 200, 180), // GitHub Copilot teal
             scope_bg: Color::Rgb(45, 45, 50),         // slightly lighter than search_bg
             scope_key_bg: Color::Rgb(60, 60, 65),     // keycap style
             separator_fg: Color::Rgb(60, 60, 65),     // subtle separator
@@ -120,6 +126,8 @@ impl Theme {
             factory_source: Color::Rgb(100, 80, 160),  // Google purple (darker for light bg)
             opencode_bubble_bg: Color::Rgb(225, 235, 250), // subtle blue tint
             opencode_source: Color::Rgb(50, 100, 200), // sky blue (darker for light bg)
+            copilot_bubble_bg: Color::Rgb(220, 240, 235), // subtle teal tint
+            copilot_source: Color::Rgb(40, 140, 120), // GitHub Copilot teal (darker for light bg)
             scope_bg: Color::Rgb(215, 215, 220),      // slightly darker than search_bg
             scope_key_bg: Color::Rgb(200, 200, 205),  // keycap style
             separator_fg: Color::Rgb(195, 195, 200),  // visible on light bg

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -210,6 +210,7 @@ fn render_results_list(frame: &mut Frame, app: &mut App, area: Rect) {
                 SessionSource::CodexCli => t.codex_source,
                 SessionSource::Factory => t.factory_source,
                 SessionSource::OpenCode => t.opencode_source,
+                SessionSource::CopilotCli => t.copilot_source,
             };
 
             // Build header with colored source indicator
@@ -354,6 +355,7 @@ fn render_preview(frame: &mut Frame, app: &mut App, area: Rect) {
                 crate::session::SessionSource::CodexCli => (t.codex_source, t.codex_bubble_bg),
                 crate::session::SessionSource::Factory => (t.factory_source, t.factory_bubble_bg),
                 crate::session::SessionSource::OpenCode => (t.opencode_source, t.opencode_bubble_bg),
+                crate::session::SessionSource::CopilotCli => (t.copilot_source, t.copilot_bubble_bg),
             },
         };
 
@@ -374,6 +376,7 @@ fn render_preview(frame: &mut Frame, app: &mut App, area: Rect) {
                 crate::session::SessionSource::CodexCli => "Codex",
                 crate::session::SessionSource::Factory => "Droid",
                 crate::session::SessionSource::OpenCode => "OpenCode",
+                crate::session::SessionSource::CopilotCli => "Copilot",
             },
         };
 

--- a/tests/fixtures/.copilot/session-state/test-copilot-001/events.jsonl
+++ b/tests/fixtures/.copilot/session-state/test-copilot-001/events.jsonl
@@ -1,0 +1,7 @@
+{"type":"session.start","data":{"sessionId":"test-copilot-001","version":1,"producer":"copilot-agent","copilotVersion":"0.0.420","startTime":"2026-01-15T10:00:00.000Z","context":{"cwd":"/test/project","gitRoot":"/test/project","branch":"main","repository":"test/project"}},"id":"ev1","timestamp":"2026-01-15T10:00:00.000Z","parentId":null}
+{"type":"user.message","data":{"content":"hello copilot","attachments":[],"interactionId":"int-001"},"id":"ev2","timestamp":"2026-01-15T10:00:05.000Z","parentId":"ev1"}
+{"type":"assistant.turn_start","data":{"turnId":"0","interactionId":"int-001"},"id":"ev3","timestamp":"2026-01-15T10:00:05.100Z","parentId":"ev2"}
+{"type":"session.model_change","data":{"newModel":"gpt-4.1"},"id":"ev4","timestamp":"2026-01-15T10:00:06.000Z","parentId":"ev3"}
+{"type":"session.info","data":{"infoType":"model","message":"Model changed to: gpt-4.1"},"id":"ev5","timestamp":"2026-01-15T10:00:06.000Z","parentId":"ev4"}
+{"type":"assistant.message","data":{"content":"Hello! How can I help you today?","messageId":"msg1","toolRequests":[],"interactionId":"int-001"},"id":"ev6","timestamp":"2026-01-15T10:00:10.000Z","parentId":"ev5"}
+{"type":"assistant.turn_end","data":{},"id":"ev7","timestamp":"2026-01-15T10:00:10.100Z","parentId":"ev6"}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -35,6 +35,11 @@ fn setup_test_env() -> TempDir {
     let codex_dst = temp_path.join(".codex");
     copy_dir_recursive(&codex_src, &codex_dst);
 
+    // Copy .copilot directory
+    let copilot_src = fixtures.join(".copilot");
+    let copilot_dst = temp_path.join(".copilot");
+    copy_dir_recursive(&copilot_src, &copilot_dst);
+
     temp_dir
 }
 
@@ -142,6 +147,22 @@ fn test_discovers_codex_sessions() {
     assert!(
         files.iter().any(|f| f.to_string_lossy().contains(".codex/sessions")),
         "Should find files in .codex/sessions"
+    );
+}
+
+#[test]
+fn test_discovers_copilot_sessions() {
+    let _lock = lock_test();
+    let temp_dir = setup_test_env();
+    std::env::set_var("RECALL_HOME_OVERRIDE", temp_dir.path());
+
+    let files = recall::parser::discover_session_files();
+
+    std::env::remove_var("RECALL_HOME_OVERRIDE");
+
+    assert!(
+        files.iter().any(|f| f.to_string_lossy().contains(".copilot/session-state")),
+        "Should find files in .copilot/session-state"
     );
 }
 
@@ -544,6 +565,27 @@ fn test_cli_search_with_source_filter() {
     // All results should be Claude
     for result in results {
         assert_eq!(result["source"], "claude");
+    }
+}
+
+#[test]
+fn test_cli_search_with_copilot_source_filter() {
+    let _lock = lock_test();
+    let temp_dir = setup_test_env();
+
+    let (stdout, _stderr, success) = run_cli(
+        &["search", "hello", "--source", "copilot", "--limit", "10"],
+        temp_dir.path(),
+    );
+
+    assert!(success);
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let results = json["results"].as_array().unwrap();
+
+    // All results should be Copilot
+    for result in results {
+        assert_eq!(result["source"], "copilot");
     }
 }
 

--- a/tests/snapshots/integration__ui_no_query_folder_scope.snap
+++ b/tests/snapshots/integration__ui_no_query_folder_scope.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration.rs
+assertion_line: 416
 expression: buffer_to_string(&terminal)
 ---
                                                                │
@@ -25,4 +26,4 @@ expression: buffer_to_string(&terminal)
 
 
 
-  ↑↓  navigate  │  Esc  quit                                         2 sessions
+  ↑↓  navigate  │  Esc  quit                                         3 sessions

--- a/tests/snapshots/integration__ui_with_query_everywhere_scope_no_results.snap
+++ b/tests/snapshots/integration__ui_with_query_everywhere_scope_no_results.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration.rs
+assertion_line: 483
 expression: buffer_to_string(&terminal)
 ---
                                                               │
@@ -25,4 +26,4 @@ expression: buffer_to_string(&terminal)
 
 
 
-  ↑↓  navigate  │  Esc  quit                                         2 sessions
+  ↑↓  navigate  │  Esc  quit                                         3 sessions

--- a/tests/snapshots/integration__ui_with_query_folder_scope_no_results.snap
+++ b/tests/snapshots/integration__ui_with_query_folder_scope_no_results.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration.rs
+assertion_line: 461
 expression: buffer_to_string(&terminal)
 ---
                                                                │
@@ -25,4 +26,4 @@ expression: buffer_to_string(&terminal)
 
 
 
-  ↑↓  navigate  │  Esc  quit                                         2 sessions
+  ↑↓  navigate  │  Esc  quit                                         3 sessions


### PR DESCRIPTION
## Background

GitHub Copilot CLI stores sessions as JSONL event logs in `~/.copilot/session-state/{uuid}/events.jsonl`
- Docs: https://docs.github.com/copilot/concepts/agents/about-copilot-cli
- Session format: https://deepwiki.com/github/copilot-cli/3.3-session-management-and-history

## Changes

- New `CopilotParser` that reads `events.jsonl`, extracts `user.message`/`assistant.message` events
- Resume: `copilot --resume={id}` (configurable via `RECALL_COPILOT_CMD`)
- Gracefully skips when `~/.copilot/session-state/` doesn't exist

## Test plan

- [x] Unit tests: path detection, event parsing, non-message event skipping (4 tests)
- [x] Integration tests: session discovery, `--source copilot` CLI filter (2 tests)
- [x] Snapshot updates for session count (2→3)
- [x] Manual: verified `search`, `list`, `read` against a real Copilot CLI v0.0.420 session

```
$ recall search "hello" --source copilot
{
  "query": "hello",
  "results": [{
    "session_id": "09e5676e-...",
    "source": "copilot",
    "resume_command": "copilot --resume=09e5676e-..."
  }]
}
```